### PR TITLE
feat: Implement forgot password flow with email OTP verification

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -30,3 +30,8 @@ export {
   useVerifySms,
   useVerifyPasskey,
 } from './useMFAVerification';
+
+// Password reset hooks
+export { useForgotPassword } from './useForgotPassword';
+export { useVerifyResetOtp } from './useVerifyResetOtp';
+export { useResetPassword } from './useResetPassword';

--- a/src/hooks/useForgotPassword.ts
+++ b/src/hooks/useForgotPassword.ts
@@ -1,0 +1,11 @@
+import { type UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { forgotPassword, type ForgotPasswordResponse } from '../services/auth.service';
+
+type UseForgotPasswordOptions = Omit<UseMutationOptions<ForgotPasswordResponse, Error, string>, 'mutationFn'>;
+
+export const useForgotPassword = (options?: UseForgotPasswordOptions) => {
+  return useMutation<ForgotPasswordResponse, Error, string>({
+    mutationFn: (email: string) => forgotPassword(email),
+    ...options,
+  });
+};

--- a/src/hooks/useResetPassword.ts
+++ b/src/hooks/useResetPassword.ts
@@ -1,0 +1,16 @@
+import { type UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { resetPassword, type ResetPasswordResponse } from '../services/auth.service';
+
+interface ResetPasswordParams {
+  resetToken: string;
+  newPassword: string;
+}
+
+type UseResetPasswordOptions = Omit<UseMutationOptions<ResetPasswordResponse, Error, ResetPasswordParams>, 'mutationFn'>;
+
+export const useResetPassword = (options?: UseResetPasswordOptions) => {
+  return useMutation<ResetPasswordResponse, Error, ResetPasswordParams>({
+    mutationFn: ({ resetToken, newPassword }: ResetPasswordParams) => resetPassword(resetToken, newPassword),
+    ...options,
+  });
+};

--- a/src/hooks/useVerifyResetOtp.ts
+++ b/src/hooks/useVerifyResetOtp.ts
@@ -1,0 +1,16 @@
+import { type UseMutationOptions, useMutation } from '@tanstack/react-query';
+import { verifyResetOtp, type VerifyResetOtpResponse } from '../services/auth.service';
+
+interface VerifyResetOtpParams {
+  email: string;
+  otp: string;
+}
+
+type UseVerifyResetOtpOptions = Omit<UseMutationOptions<VerifyResetOtpResponse, Error, VerifyResetOtpParams>, 'mutationFn'>;
+
+export const useVerifyResetOtp = (options?: UseVerifyResetOtpOptions) => {
+  return useMutation<VerifyResetOtpResponse, Error, VerifyResetOtpParams>({
+    mutationFn: ({ email, otp }: VerifyResetOtpParams) => verifyResetOtp(email, otp),
+    ...options,
+  });
+};

--- a/src/pages/auth/ForgotPasswordPage.tsx
+++ b/src/pages/auth/ForgotPasswordPage.tsx
@@ -1,69 +1,168 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Button } from '@vritti/quantum-ui/Button';
 import { Field, FieldGroup, Form } from '@vritti/quantum-ui/Form';
+import { OTPField } from '@vritti/quantum-ui/OTPField';
 import { TextField } from '@vritti/quantum-ui/TextField';
 import { Typography } from '@vritti/quantum-ui/Typography';
-import { ArrowLeft, Mail } from 'lucide-react';
+import { AlertCircle, ArrowLeft, Mail } from 'lucide-react';
 import type React from 'react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { Link } from 'react-router-dom';
-import type { ForgotPasswordFormData } from '../../schemas/auth';
-import { forgotPasswordSchema } from '../../schemas/auth';
+import { Link, useNavigate } from 'react-router-dom';
+import { useForgotPassword, useVerifyResetOtp } from '../../hooks';
+import type { ForgotPasswordFormData, OTPFormData } from '../../schemas/auth';
+import { forgotPasswordSchema, otpSchema } from '../../schemas/auth';
+
+type Step = 'email' | 'otp';
 
 export const ForgotPasswordPage: React.FC = () => {
-  const [isSuccess, setIsSuccess] = useState(false);
+  const navigate = useNavigate();
+  const [step, setStep] = useState<Step>('email');
   const [submittedEmail, setSubmittedEmail] = useState('');
+  const [error, setError] = useState<string | null>(null);
 
-  const form = useForm<ForgotPasswordFormData>({
+  const forgotPasswordMutation = useForgotPassword();
+  const verifyResetOtpMutation = useVerifyResetOtp();
+
+  // Email form
+  const emailForm = useForm<ForgotPasswordFormData>({
     resolver: zodResolver(forgotPasswordSchema),
-    defaultValues: {
-      email: '',
-    },
+    defaultValues: { email: '' },
   });
 
-  const onSubmit = async (data: ForgotPasswordFormData) => {
-    // TODO: Implement API call
-    await new Promise((resolve) => setTimeout(resolve, 1500));
-    console.log('Password reset email sent to:', data.email);
-    setSubmittedEmail(data.email);
-    setIsSuccess(true);
+  // OTP form
+  const otpForm = useForm<OTPFormData>({
+    resolver: zodResolver(otpSchema),
+    defaultValues: { code: '' },
+  });
+
+  const onEmailSubmit = async (data: ForgotPasswordFormData) => {
+    setError(null);
+    try {
+      await forgotPasswordMutation.mutateAsync(data.email);
+      setSubmittedEmail(data.email);
+      setStep('otp');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to send reset code. Please try again.';
+      setError(message);
+    }
   };
 
-  if (isSuccess) {
+  const onOtpSubmit = async (data: OTPFormData) => {
+    setError(null);
+    try {
+      const result = await verifyResetOtpMutation.mutateAsync({
+        email: submittedEmail,
+        otp: data.code,
+      });
+      navigate(`../reset-password?token=${encodeURIComponent(result.resetToken)}&email=${encodeURIComponent(submittedEmail)}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Invalid or expired code. Please try again.';
+      setError(message);
+    }
+  };
+
+  const handleResend = async () => {
+    setError(null);
+    try {
+      await forgotPasswordMutation.mutateAsync(submittedEmail);
+      otpForm.reset();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to resend code. Please try again.';
+      setError(message);
+    }
+  };
+
+  // OTP verification step
+  if (step === 'otp') {
     return (
-      <div className="space-y-6 text-center">
-        <div className="space-y-2">
+      <div className="space-y-6">
+        {/* Back to email step */}
+        <button
+          type="button"
+          onClick={() => {
+            setStep('email');
+            setError(null);
+            otpForm.reset();
+          }}
+          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back
+        </button>
+
+        {/* Header */}
+        <div className="text-center space-y-2">
           <Typography variant="h3" align="center" className="text-foreground">
-            Check your email
+            Verify your email
           </Typography>
           <Typography variant="body2" align="center" intent="muted">
-            We've sent a password reset link to
+            We sent a verification code to
           </Typography>
           <Typography variant="body2" align="center" className="text-foreground font-medium">
             {submittedEmail}
           </Typography>
         </div>
 
-        <div className="space-y-4">
-          <Typography variant="body2" align="center" intent="muted">
-            Didn't receive the email? Check your spam folder or
+        {/* Enter verification code label */}
+        <div className="text-center">
+          <Typography variant="body2" className="text-foreground font-medium">
+            Enter verification code
           </Typography>
-          <Button
-            variant="outline"
-            className="w-full border-border text-foreground"
-            onClick={() => {
-              setIsSuccess(false);
-              form.reset();
-            }}
-          >
-            Try another email
-          </Button>
         </div>
+
+        {/* Error */}
+        {error && (
+          <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-lg flex items-start gap-2">
+            <AlertCircle className="h-5 w-5 text-destructive flex-shrink-0 mt-0.5" />
+            <Typography variant="body2" className="text-destructive">
+              {error}
+            </Typography>
+          </div>
+        )}
+
+        {/* OTP Form */}
+        <Form form={otpForm} onSubmit={onOtpSubmit}>
+          <FieldGroup>
+            <div className="flex justify-center">
+              <OTPField
+                name="code"
+                onChange={(value) => {
+                  if (value.length === 6 && !verifyResetOtpMutation.isPending) {
+                    otpForm.handleSubmit(onOtpSubmit)();
+                  }
+                }}
+              />
+            </div>
+
+            <Field className="pt-2">
+              <Button
+                type="submit"
+                className="w-full bg-primary text-primary-foreground"
+                disabled={verifyResetOtpMutation.isPending}
+              >
+                {verifyResetOtpMutation.isPending ? 'Verifying...' : 'Verify'}
+              </Button>
+            </Field>
+
+            {/* Resend */}
+            <div className="text-center">
+              <Button
+                type="button"
+                variant="link"
+                className="p-0 h-auto text-sm"
+                onClick={handleResend}
+                disabled={forgotPasswordMutation.isPending || verifyResetOtpMutation.isPending}
+              >
+                {forgotPasswordMutation.isPending ? 'Sending...' : 'Resend code'}
+              </Button>
+            </div>
+          </FieldGroup>
+        </Form>
 
         <Link
           to="../login"
-          className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
+          className="flex justify-center items-center gap-2 text-sm text-muted-foreground hover:text-foreground"
         >
           <ArrowLeft className="h-4 w-4" />
           Back to sign in
@@ -72,6 +171,7 @@ export const ForgotPasswordPage: React.FC = () => {
     );
   }
 
+  // Email entry step
   return (
     <div className="space-y-6">
       {/* Back Link */}
@@ -86,17 +186,27 @@ export const ForgotPasswordPage: React.FC = () => {
           Reset your password
         </Typography>
         <Typography variant="body2" align="center" intent="muted">
-          Enter your email to receive a reset link
+          Enter your email to receive a verification code
         </Typography>
       </div>
 
+      {/* Error */}
+      {error && (
+        <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-lg flex items-start gap-2">
+          <AlertCircle className="h-5 w-5 text-destructive flex-shrink-0 mt-0.5" />
+          <Typography variant="body2" className="text-destructive">
+            {error}
+          </Typography>
+        </div>
+      )}
+
       {/* Form */}
-      <Form form={form} onSubmit={onSubmit}>
+      <Form form={emailForm} onSubmit={onEmailSubmit}>
         <FieldGroup>
           <TextField
             name="email"
             label="Email Address"
-            placeholder="Enter your email"
+            placeholder="you@company.com"
             startAdornment={<Mail className="h-4 w-4 text-muted-foreground" />}
           />
 
@@ -104,9 +214,9 @@ export const ForgotPasswordPage: React.FC = () => {
             <Button
               type="submit"
               className="w-full bg-primary text-primary-foreground"
-              disabled={form.formState.isSubmitting}
+              disabled={forgotPasswordMutation.isPending}
             >
-              {form.formState.isSubmitting ? 'Sending reset link...' : 'Send reset link'}
+              {forgotPasswordMutation.isPending ? 'Sending...' : 'Send reset code'}
             </Button>
           </Field>
         </FieldGroup>

--- a/src/pages/auth/ResetPasswordPage.tsx
+++ b/src/pages/auth/ResetPasswordPage.tsx
@@ -1,0 +1,180 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Button } from '@vritti/quantum-ui/Button';
+import { Field, FieldGroup, Form } from '@vritti/quantum-ui/Form';
+import { PasswordField } from '@vritti/quantum-ui/PasswordField';
+import { Typography } from '@vritti/quantum-ui/Typography';
+import { AlertCircle, CheckCircle, KeyRound } from 'lucide-react';
+import type React from 'react';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useResetPassword } from '../../hooks';
+import type { ResetPasswordFormData } from '../../schemas/auth';
+import { resetPasswordSchema } from '../../schemas/auth';
+
+export const ResetPasswordPage: React.FC = () => {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+
+  const [error, setError] = useState<string | null>(null);
+  const [isSuccess, setIsSuccess] = useState(false);
+
+  const resetPasswordMutation = useResetPassword();
+
+  const form = useForm<ResetPasswordFormData>({
+    resolver: zodResolver(resetPasswordSchema),
+    defaultValues: {
+      password: '',
+      confirmPassword: '',
+    },
+  });
+
+  const onSubmit = async (data: ResetPasswordFormData) => {
+    if (!token) return;
+    setError(null);
+    try {
+      await resetPasswordMutation.mutateAsync({
+        resetToken: token,
+        newPassword: data.password,
+      });
+      setIsSuccess(true);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to reset password. Please try again.';
+      setError(message);
+    }
+  };
+
+  // Redirect to login after success
+  useEffect(() => {
+    if (!isSuccess) return;
+    const timer = setTimeout(() => {
+      navigate('../login', { replace: true });
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [isSuccess, navigate]);
+
+  // Missing token — invalid access
+  if (!token) {
+    return (
+      <div className="space-y-6 text-center">
+        <div className="flex justify-center">
+          <div className="w-9 h-9 rounded-full bg-destructive/10 flex items-center justify-center">
+            <AlertCircle className="h-5 w-5 text-destructive" />
+          </div>
+        </div>
+        <div className="space-y-2">
+          <Typography variant="h3" align="center" className="text-foreground">
+            Invalid reset link
+          </Typography>
+          <Typography variant="body2" align="center" intent="muted">
+            This password reset link is invalid or has expired. Please request a new one.
+          </Typography>
+        </div>
+        <Link
+          to="../forgot-password"
+          className="inline-flex items-center justify-center text-sm text-primary hover:underline"
+        >
+          Request new reset code
+        </Link>
+      </div>
+    );
+  }
+
+  // Success state
+  if (isSuccess) {
+    return (
+      <div className="space-y-6 text-center">
+        <div className="flex justify-center">
+          <div className="w-9 h-9 rounded-full bg-success/15 flex items-center justify-center">
+            <CheckCircle className="h-5 w-5 text-success" />
+          </div>
+        </div>
+        <div className="space-y-2">
+          <Typography variant="h3" align="center" className="text-foreground">
+            Password reset successful
+          </Typography>
+          <Typography variant="body2" align="center" intent="muted">
+            Your password has been updated. Redirecting to sign in...
+          </Typography>
+        </div>
+        <Link
+          to="../login"
+          className="inline-flex items-center justify-center text-sm text-primary hover:underline"
+        >
+          Sign in now
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Key icon */}
+      <div className="flex justify-center">
+        <div className="w-9 h-9 rounded-full bg-primary/10 flex items-center justify-center">
+          <KeyRound className="h-5 w-5 text-primary" />
+        </div>
+      </div>
+
+      {/* Header */}
+      <div className="text-center space-y-2">
+        <Typography variant="h3" align="center" className="text-foreground">
+          Reset Your Password
+        </Typography>
+        <Typography variant="body2" align="center" intent="muted">
+          Choose a strong password for your account
+        </Typography>
+      </div>
+
+      {/* Error */}
+      {error && (
+        <div className="p-3 bg-destructive/10 border border-destructive/20 rounded-lg flex items-start gap-2">
+          <AlertCircle className="h-5 w-5 text-destructive flex-shrink-0 mt-0.5" />
+          <Typography variant="body2" className="text-destructive">
+            {error}
+          </Typography>
+        </div>
+      )}
+
+      {/* Form */}
+      <Form form={form} onSubmit={onSubmit}>
+        <FieldGroup>
+          <PasswordField
+            name="password"
+            label="New Password"
+            placeholder="Enter your new password"
+            showStrengthIndicator
+          />
+
+          <PasswordField
+            name="confirmPassword"
+            label="Confirm Password"
+            placeholder="Re-enter your new password"
+            showMatchIndicator
+          />
+
+          <Field>
+            <Button
+              type="submit"
+              className="w-full bg-primary text-primary-foreground"
+              disabled={resetPasswordMutation.isPending}
+            >
+              {resetPasswordMutation.isPending ? 'Resetting...' : 'Reset Password'}
+            </Button>
+          </Field>
+        </FieldGroup>
+      </Form>
+
+      {/* Back to Login */}
+      <div className="text-center">
+        <Link
+          to="../login"
+          className="text-sm text-muted-foreground hover:text-foreground"
+        >
+          Back to Login
+        </Link>
+      </div>
+    </div>
+  );
+};

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -7,6 +7,7 @@ import './index.css';
 import { ForgotPasswordPage } from './pages/auth/ForgotPasswordPage';
 import { LoginPage } from './pages/auth/LoginPage';
 import { MFAVerificationPage } from './pages/auth/MFAVerificationPage';
+import { ResetPasswordPage } from './pages/auth/ResetPasswordPage';
 import { SignupPage } from './pages/auth/SignupPage';
 import { SignupSuccessPage } from './pages/auth/SignupSuccessPage';
 import { OAuthErrorPage } from './pages/onboarding/OAuthErrorPage';
@@ -40,6 +41,10 @@ export const authRoutes: RouteObject[] = [
       {
         path: 'forgot-password',
         element: <ForgotPasswordPage />,
+      },
+      {
+        path: 'reset-password',
+        element: <ResetPasswordPage />,
       },
       {
         path: 'mfa-verify',

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -65,6 +65,27 @@ export const setPasswordSchema = z
 export type SetPasswordFormData = z.infer<typeof setPasswordSchema>;
 
 /**
+ * Validation schema for reset password form
+ */
+export const resetPasswordSchema = z
+  .object({
+    password: z
+      .string()
+      .min(8, 'Password must be at least 8 characters')
+      .regex(/[A-Z]/, 'Password must contain at least one uppercase letter')
+      .regex(/[a-z]/, 'Password must contain at least one lowercase letter')
+      .regex(/[0-9]/, 'Password must contain at least one number')
+      .regex(/[^A-Za-z0-9]/, 'Password must contain at least one special character'),
+    confirmPassword: z.string().min(1, 'Please confirm your password'),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords don't match",
+    path: ['confirmPassword'],
+  });
+
+export type ResetPasswordFormData = z.infer<typeof resetPasswordSchema>;
+
+/**
  * Validation schema for OTP verification
  */
 export const otpSchema = z.object({

--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -534,3 +534,89 @@ export async function verifyPasskeyLogin(
 
   return response.data;
 }
+
+// ============================================================================
+// Password Reset API Functions
+// ============================================================================
+
+/**
+ * Response from forgot password request
+ */
+export interface ForgotPasswordResponse {
+  success: boolean;
+  message: string;
+}
+
+/**
+ * Response from OTP verification - returns reset token
+ */
+export interface VerifyResetOtpResponse {
+  resetToken: string;
+}
+
+/**
+ * Response from password reset
+ */
+export interface ResetPasswordResponse {
+  success: boolean;
+  message: string;
+}
+
+/**
+ * Requests a password reset OTP to be sent to the provided email
+ *
+ * @param email - Email address to send the reset code to
+ * @returns Promise resolving to success response
+ */
+export async function forgotPassword(email: string): Promise<ForgotPasswordResponse> {
+  const response: AxiosResponse<ForgotPasswordResponse> = await axios.post(
+    "cloud-api/auth/forgot-password",
+    { email },
+    {
+      public: true,
+      showSuccessToast: false,
+    },
+  );
+
+  return response.data;
+}
+
+/**
+ * Verifies the password reset OTP and returns a reset token
+ *
+ * @param email - Email address used for password reset
+ * @param otp - 6-digit OTP code from email
+ * @returns Promise resolving to reset token
+ */
+export async function verifyResetOtp(email: string, otp: string): Promise<VerifyResetOtpResponse> {
+  const response: AxiosResponse<VerifyResetOtpResponse> = await axios.post(
+    "cloud-api/auth/verify-reset-otp",
+    { email, otp },
+    {
+      public: true,
+      showSuccessToast: false,
+    },
+  );
+
+  return response.data;
+}
+
+/**
+ * Resets the password using the reset token from OTP verification
+ *
+ * @param resetToken - Token received after OTP verification
+ * @param newPassword - New password to set
+ * @returns Promise resolving to success response
+ */
+export async function resetPassword(resetToken: string, newPassword: string): Promise<ResetPasswordResponse> {
+  const response: AxiosResponse<ResetPasswordResponse> = await axios.post(
+    "cloud-api/auth/reset-password",
+    { resetToken, newPassword },
+    {
+      public: true,
+      showSuccessToast: false,
+    },
+  );
+
+  return response.data;
+}


### PR DESCRIPTION
## Summary
- Implement complete forgot password flow with email OTP verification
- Add ForgotPasswordPage with two-step flow (email entry → OTP verification)
- Create ResetPasswordPage for setting new password
- Add TanStack Query hooks for password reset mutations

## Changes

### Pages
- **ForgotPasswordPage** - Two-step flow: email entry → OTP verification
- **ResetPasswordPage** - Password reset form with strength indicator

### Hooks
- `useForgotPassword` - Request OTP via email
- `useVerifyResetOtp` - Verify OTP and get reset token
- `useResetPassword` - Reset password with token

### Services
- Added `forgotPassword()`, `verifyResetOtp()`, `resetPassword()` to auth.service.ts

### Schemas
- Added `resetPasswordSchema` with strong password validation

### Routes
- Added `/reset-password` route

## Features
- Auto-submit OTP on full 6-digit entry
- Password strength indicator
- Confirm password matching
- Success state with 3-second auto-redirect to login
- Error handling with visual feedback
- Resend OTP functionality
- Back navigation between steps

## Test plan
- [ ] Enter email and receive OTP
- [ ] Verify OTP and navigate to reset page
- [ ] Test invalid OTP error handling
- [ ] Reset password with strong password
- [ ] Verify redirect to login after success
- [ ] Test expired/invalid token handling

## Related
- Backend PR: vritti-ai-platforms/api-nexus#4
- Closes #1